### PR TITLE
Add bug bounty opt-out notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # soroban-test-examples
 Example contracts for integration testing
+
+---
+
+> **Note:** This repository is not in scope for the Stellar Development Foundation bug bounty program. Vulnerabilities found in this repo are not eligible for rewards.


### PR DESCRIPTION
Adds a note that this repo is not in scope for the SDF bug bounty program.